### PR TITLE
Fixed '/edit write' command

### DIFF
--- a/src/com/nowilltolife/ingameeditor/commands/EditCommand.java
+++ b/src/com/nowilltolife/ingameeditor/commands/EditCommand.java
@@ -248,7 +248,7 @@ public class EditCommand implements CommandExecutor {
 						int line = Integer.parseInt(args[1]);
 						try {
 							List<String> lines = Files.readAllLines(Paths.get(session.get(sender.getName()).getAbsolutePath()));
-							if(line >= lines.size()) {
+							if(line <= lines.size()) {
 								String previous = lines.get(line-1);
 								StringBuilder builder = new StringBuilder();
 								for (int i = 2; i < args.length; i++) {
@@ -257,6 +257,9 @@ public class EditCommand implements CommandExecutor {
 								lines.set(line-1, builder.substring(1));
 								Files.write(Paths.get(session.get(sender.getName()).getAbsolutePath()), lines, Charset.forName("UTF-8"));
 								sender.sendMessage(Main.prefix + "§7You changed the content of line §a" + args[1] + " §7from: '§a" + previous + "§7' to '§a" + builder.substring(1) + "§7'");
+							}
+							else {
+								sender.sendMessage(Main.errorprefix + " the file only has " + lines.size() + " line(s)!");
 							}
 						} catch (IOException e) {
 							sender.sendMessage(Main.errorprefix + " while trying to save file. Is the file still there?");


### PR DESCRIPTION
I was using the plugin and i noticed that the "/edit write" wasn't working: the operator in the 252 line was inverted. When a player passed a line higher then the file lines amount, the plugin continued to execute the write action and returned a error in the console. And, when the opposite occurred, it just jumped the if without warning nothing in the chat.

So i changed the operator and added a else to that if, so, if the players pass a line higher than should, it will send the error menssage used in others parts of the code.

Also, i tested the plugin in a 1.16.5 server and it worked fine :D 